### PR TITLE
add_setInterval

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,0 +1,53 @@
+$(document).on('turbolinks:load', function() {
+  $(function(){
+    function buildHTML(message){
+      var addImgTag = (message.image.url !== null)? `<img src="${ message.image.url }", class="contents__right--main__message_image">`:''
+      var html =`
+        <li class="contents__right--main__message_wrapper" data-message-id="${message.id}">
+          <div class="contents__right--main__message_name">
+            ${ message.user_name }
+          </div>
+          <div class="contents__right--main__message_day">
+            ${ message.created_at }
+          </div>
+          <div class="contents__right--main__message_text">
+            ${ message.content }
+          </div>
+          ${addImgTag}
+        </div>
+        `
+        return html;
+    }
+    $(function(){
+      if (window.location.href.match(/\/groups\/\d+\/messages/)) {
+        var set_Interval = setInterval(update,10000);
+      } else {
+        clearInterval(set_Interval);
+      };
+    });
+    function update(){
+      var message_id = ''
+      if($('.contents__right--main__message_wrapper')[0]){
+        var message_id = $('.contents__right--main__message_wrapper:last').attr('data-message-id');
+      }else{
+        var message_id = 0
+      }
+      $.ajax({
+        url: location.href,
+        type: 'GET',
+        data: { message: { id: message_id } },
+        dataType: 'json'
+      })
+      .done(function(data){
+        $.each(data,function(i,data) {
+          var html = buildHTML(data);
+          $('.contents__right--main__message').append(html);
+        });
+        $('#scroll').animate({scrollTop:$('#scroll')[0].scrollHeight});
+      })
+      .fail(function(){
+        alert('自動更新に失敗しました');
+      });
+    };
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,10 @@ before_action :set_group_date
 def index
   @message=Message.new
   @messages=@group.messages.includes(:user)
+  respond_to do |format|
+    format.html
+    format.json{ @new_message = Message.where('id > ?', params[:message][:id]) }
+  end
 end
 
 def create

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.contents__right--main__message
+%li.contents__right--main__message_wrapper{"data-message-id": "#{message.id}"}
  .contents__right--main__message_name
   = message.user.name
  .contents__right--main__message_day
@@ -6,4 +6,4 @@
  .contents__right--main__message_text
   - if message.content.present?
    = message.content
-   = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+   = image_tag message.image.url, class: 'contents__right--main__message_image' if message.image.present?

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,8 +15,17 @@
     - @group.users.each do|member|
      .contents__right--main__room_name
       = member.name
-   .contents__right--main__message
 
+   %ul.contents__right--main__message
+    - @messages.each do|message|
+     %li.contents__right--main__message_wrapper{"data-message-id": "#{message.id}"}
+      .contents__right--main__message_name
+       = message.user.name
+      .contents__right--main__message_day
+       = message.created_at
+      .contents__right--main__message_text
+       = message.content
+      %img.contents__right--main__message_image{src: "#{ message.image }"}
 
   .contents__right--bottom
    = form_for [@group,@message] ,html:{id:'new_comment'} do |f|

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,15 +17,7 @@
       = member.name
 
    %ul.contents__right--main__message
-    - @messages.each do|message|
-     %li.contents__right--main__message_wrapper{"data-message-id": "#{message.id}"}
-      .contents__right--main__message_name
-       = message.user.name
-      .contents__right--main__message_day
-       = message.created_at
-      .contents__right--main__message_text
-       = message.content
-      %img.contents__right--main__message_image{src: "#{ message.image }"}
+    = render @messages
 
   .contents__right--bottom
    = form_for [@group,@message] ,html:{id:'new_comment'} do |f|

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,11 @@
+if @new_message.present?
+  json.array! @new_message do |message|
+    json.user_name  message.user.name
+    json.user_id  message.user_id
+    json.content  message.content
+    json.image message.image
+    json.created_at message.created_at
+    json.id @message.id
+  end
+end
+


### PR DESCRIPTION
#  WHAT
## 非同期通信での自動更新機能の追加
１）javascriptファイル（index.js）の作成
２）messageコントローラのindexアクション修正
３）jsonファイルの作成
４）HTMLの調整

# WHY
１）javascriptファイルの作成・・処理のポイント

・$(document).on('turbolinks:load', function() {
　→turbolinksの仕様により、他画面への遷移後にもsetintervalが動作してしまう現象を止めるための処理

・if (window.location.href.match(/\/groups\/\d+\/messages/)) {
　var set_Interval = setInterval(update,5000);
　→setintervalを「groups/group_id/messages」パスでのみ作動させるため、windowオブジェクトの
　　locationから現在表示されているurlを取得し正規表現でmatch処理をした

・} else { clearInterval(set_Interval); };
　→パスが上記とmachしない場合はclearintervalにより自動更新の処理を止める

・if($('.contents__right--main__message_wrapper')[0]){
　var message_id = $('.contents__right--main__message_wrapper:last').attr('data-message-id');
　}else{ var message_id = 0 }
　→「.contents~」クラスを持つ要素（メッセージの投稿）がある場合はその最後の要素の
　　「data-message-id」属性の属性値（数値）を取得、メッセージの投稿がない場合は「０」を
　　変数message_idへ代入

・$.ajax{
　~data: { message: { id: message_id } },
　→最後の投稿メッセージから取得したmessage_idの値をコントローラへ渡す

・.done(function(data){
　→以降、非同期通信で返されたjsonファイルから値を取得しhtmlへ反映し生成する処理

２）messageコントローラのindexアクションに追記

・format.json{ @new_message = Message.where('id > ?', params[:message][:id]) }
　→Messageテーブルからidがjsファイルから渡したmessage_id（最後の投稿のid）より
　　大きいもの（最新の投稿より後にデータベースに記録された投稿データ）を取得する処理

３）jsonファイルの作成

・if @new_message.present?
　→２）でデータが取得できた時に処理を実行する

・ json.array! @new_message do |message|
　→２）で取得したデータを配列化としてjsファイルに渡すための処理

４）HTMLを調整

・%li.contents__right--main__message_wrapper{"data-message-id": "#{message.id}"}
　→上記処理のため、＜li.contents〜＞要素に{"data-message-id": "#{message.id}"}として
　　message.idを追加する他、処理を正常に動作させるための微細な修正を行った